### PR TITLE
Reflect German law change

### DIFF
--- a/tor-exit-notice_DE.html
+++ b/tor-exit-notice_DE.html
@@ -292,8 +292,8 @@ transmitted.</p>
 <!-- Germany only -->
 
 <p>As a German organization, we fully comply
-with <a href="https://www.gesetze-im-internet.de/tmg/__15.html">Telemediengesetz
-§15</a> (the German telemedia law), which prohibits to log any
+with <a href="https://www.gesetze-im-internet.de/ttdsg/__9.html">Telekommunikation-Telemedien-Datenschutz-Gesetz
+§9</a> (the German telemedia data protection law), which prohibits to log any
 personally identifiable data or usage data unless required for billing
 purposes. As we do not charge for using our services, we will never be
 able to keep any connection data.<p/>


### PR DESCRIPTION
§15 TMG does not exist anymore. This section is now regulated in $9 TTDSG.

https://www.gesetze-im-internet.de/ttdsg/__9.html

Decided and pronounced in June 28 2021 in https://dejure.org/ext/a5eb168e2eff9a8d705338e07b849a17